### PR TITLE
fixed a bunch of clippy warnings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -52,13 +52,13 @@ impl Error {
     /// ```
     pub fn print_error<W: Write>(&self, err_out: &mut W) {
         match *self {
-            Error::FileParsingFailed { ref desc, ref errors } => {
+            Error::FileParsingFailed { desc, ref errors } => {
                 writeln!(err_out, "Failed to parse {}{}", desc, if errors.is_empty() { '.' } else { ':' }).unwrap();
                 for err in errors {
                     writeln!(err_out, "  {}", err).unwrap()
                 }
             }
-            Error::Io { ref desc, ref op } => {
+            Error::Io { desc, op } => {
                 // Strip the last 'e', if any, so we get correct inflection for continuous times
                 let op = uppercase_first(if op.ends_with('e') {
                     &op[..op.len() - 1]
@@ -67,7 +67,7 @@ impl Error {
                 });
                 writeln!(err_out, "{}ing {} failed.", op, desc).unwrap()
             }
-            Error::Ui { ref desc, ref error } => writeln!(err_out, "Failed to {}: {}.", desc, error).unwrap(),
+            Error::Ui { desc, ref error } => writeln!(err_out, "Failed to {}: {}.", desc, error).unwrap(),
         }
     }
 

--- a/src/ops/style.rs
+++ b/src/ops/style.rs
@@ -23,7 +23,7 @@ use conrod::widget::Button;
 /// butan.set(buttid, &mut ui_widgets);
 /// # }
 /// ```
-pub fn set_button_style<'a, S>(button: &mut Button<'a, S>) {
+pub fn set_button_style<S>(button: &mut Button<S>) {
     button.style.color = Some(TRANSPARENT);
     button.style.border = None;
     button.style.border_color = Some(TRANSPARENT);

--- a/src/ops/widgets.rs
+++ b/src/ops/widgets.rs
@@ -187,8 +187,8 @@ impl Widgets {
     /// # }
     /// ```
     pub fn update(&self, mut ui_wdgts: UiCell, mut cur_state: &mut GameState) {
-        match cur_state {
-            &mut GameState::MainMenu => {
+        match *cur_state {
+            GameState::MainMenu => {
                 Canvas::new()
                     .flow_down(&[(self.start_button_canvas, Canvas::new().color(DARK_CHARCOAL)),
                                  (self.leaderboard_button_canvas, Canvas::new().color(DARK_CHARCOAL)),
@@ -210,7 +210,7 @@ impl Widgets {
                     state::press_exit(cur_state);
                 }
             }
-            &mut GameState::ChooseDifficulty => {
+            GameState::ChooseDifficulty => {
                 Canvas::new()
                     .flow_down(&[(self.easy_button_canvas, Canvas::new().color(DARK_CHARCOAL)),
                                  (self.normal_button_canvas, Canvas::new().color(DARK_CHARCOAL)),
@@ -237,7 +237,7 @@ impl Widgets {
                     state::press_back(cur_state);
                 }
             }
-            &mut GameState::Playing { .. } => {
+            GameState::Playing { .. } => {
                 Canvas::new()
                     .flow_down(&[(self.top_label_canvas, Canvas::new().color(DARK_CHARCOAL)), (self.mango_button_canvas, Canvas::new().color(DARK_CHARCOAL))])
                     .set(self.main_canvas, &mut ui_wdgts);
@@ -251,7 +251,7 @@ impl Widgets {
                 let mango_button_clicked = mango_button.set(self.mango_button, &mut ui_wdgts).was_clicked();
                 state::end_mango(cur_state, mango_button_clicked, last_fruit.is_none());
             }
-            &mut GameState::GameOver { difficulty: _, score, name: _ } => {
+            GameState::GameOver { score, .. } => {
                 Canvas::new()
                     .flow_down(&[(self.top_label_canvas, Canvas::new().color(DARK_CHARCOAL)),
                                  (self.score_label_canvas, Canvas::new().color(DARK_CHARCOAL)),
@@ -263,7 +263,7 @@ impl Widgets {
                 Widgets::paddded_text("Game over", self.top_label_canvas, Align::Middle).set(self.top_label, &mut ui_wdgts);
                 Widgets::paddded_text(&format!("Score: {}", score), self.score_label_canvas, Align::Middle).set(self.score_label, &mut ui_wdgts);
 
-                let (mut pressed, correct_name) = if let &mut GameState::GameOver { difficulty: _, score: _, ref mut name } = cur_state {
+                let (mut pressed, correct_name) = if let GameState::GameOver { ref mut name, .. } = *cur_state {
                     let name_c = name.clone();
                     let name_input = TextBox::new(&name_c)
                         .color(DARK_CHARCOAL)
@@ -298,8 +298,8 @@ impl Widgets {
                     state::press_back(cur_state);
                 }
             }
-            &mut GameState::DisplayLeaderboard(_) => {
-                if let &mut GameState::DisplayLeaderboard(ref ldrbrd) = cur_state {
+            GameState::DisplayLeaderboard(_) => {
+                if let GameState::DisplayLeaderboard(ref ldrbrd) = *cur_state {
                     let leader_n = cmp::min(ldrbrd.len(), 10);
 
                     let mut canvases = Vec::with_capacity(leader_n + 2);
@@ -324,9 +324,9 @@ impl Widgets {
                     state::press_back(cur_state);
                 }
             }
-            &mut GameState::GameEnded { .. } |
-            &mut GameState::LoadLeaderboard |
-            &mut GameState::Exit => {
+            GameState::GameEnded { .. } |
+            GameState::LoadLeaderboard |
+            GameState::Exit => {
                 Canvas::new().color(DARK_CHARCOAL).set(self.main_canvas, &mut ui_wdgts);
             }
         }
@@ -339,7 +339,7 @@ impl Widgets {
             .mid_top_with_margin_on(canvas, 20.0)
     }
 
-    fn paddded_text<'a>(label: &'a str, canvas: Id, alignment: Align) -> Text<'a> {
+    fn paddded_text(label: &str, canvas: Id, alignment: Align) -> Text {
         Text::new(label)
             .color(WHITE)
             .padded_w_of(canvas, 5.0)

--- a/src/options.rs
+++ b/src/options.rs
@@ -92,7 +92,7 @@ impl Options {
     fn size_validator(s: String) -> Result<(), String> {
         match Options::parse_size(&s) {
             None => Err(format!("\"{}\" is not a valid size (in format \"NNNxMMM\")", s)),
-            Some((0, _)) | Some((_, 0)) => Err(format!("Can't resize image to size 0")),
+            Some((0, _)) | Some((_, 0)) => Err("Can't resize image to size 0".to_string()),
             Some(_) => Ok(()),
         }
     }

--- a/tests/ops/state/tick_mango.rs
+++ b/tests/ops/state/tick_mango.rs
@@ -26,7 +26,7 @@ fn from_playing_mango() {
     assert_eq!(state::tick_mango(&mut s), None);
 
     match s {
-        GameState::Playing { difficulty, score, fruit: _ } => {
+        GameState::Playing { difficulty, score, .. } => {
             assert_eq!(score, 101);
             assert_eq!(difficulty, Difficulty::Easy);
         }
@@ -44,7 +44,7 @@ fn from_playing_not_mango() {
     assert_eq!(state::tick_mango(&mut s), Some(0));
 
     match s {
-        GameState::Playing { difficulty, score, fruit: _ } => {
+        GameState::Playing { difficulty, score, .. } => {
             assert_eq!(score, 101);
             assert_eq!(difficulty, Difficulty::Easy);
         }


### PR DESCRIPTION
There were mostly readability things (though some clones removed may be beneficial for perf, too).

Basically I ran [clippy](https://github.com/Manishearth/rust-clippy) with `cargo clippy -- -A float_cmp` (because you do a lot of floating point comparisons in tests which I didn't want to address) and went through the warnings to fix them.
